### PR TITLE
Fix ocaml-compiler.5.3.0~rc1 package

### DIFF
--- a/packages/ocaml-compiler/ocaml-compiler.5.3.0~rc1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.3.0~rc1/opam
@@ -31,22 +31,6 @@ depends: [
 
   "ocaml-beta" {opam-version < "2.1.0"}
 
-  # Architecture (non-Windows)
-  # opam-repository at present requires that ocaml-base-compiler is installed
-  # using an architecture which matches the machine's, since arch is used in
-  # available fields. Cross-compilation at this stage is an unstable accident.
-  "host-arch-arm32" {arch = "arm32" & post}
-  "host-arch-arm64" {arch = "arm64" & post}
-  "host-arch-ppc64" {arch = "ppc64" & post}
-  "host-arch-riscv64" {arch = "riscv64" & post}
-  "host-arch-s390x" {arch = "s390x" & post}
-  # The Windows ports explicitly select the architecture (see below) this
-  # facility is not yet available for other platforms.
-  "host-arch-x86_32" {os != "win32" & arch = "x86_32" & post}
-  ("host-arch-x86_64" {os != "win32" & arch = "x86_64" & post} |
-   ("host-arch-x86_32" {os != "win32" & arch = "x86_64" & post} & "ocaml-option-32bit" {os != "win32" & arch = "x86_64"}))
-  "host-arch-unknown" {os != "win32" & arch != "arm32" & arch != "arm64" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & arch != "x86_32" & arch != "x86_64" & post}
-
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
@@ -55,9 +39,10 @@ depends: [
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
      (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
-      ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
-  # Non-Windows systems
-   "host-system-other" {os != "win32" & post})
+      ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"})))
+  # Non-Windows systems need to install something to satisfy this formula, so
+  # repeat the base-unix dependency
+   "base-unix" {os != "win32" & post})
 
   # All the 32-bit architectures are bytecode-only
   "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}


### PR DESCRIPTION
The problem before is that we _had_ a formula something like `("host-system-mingw" & "bar_a" {os = "win32"} | "host-system-msvc" & "bar_b" {os = "win32"} | "host-system-other" {os != "win32"})`. In removing `host-system-other`, this left the problem that the entire formula couldn't be satisfied on non-Windows systems. It's not possible to put `{os = "win32"}` on all the packages in the remaining formula because the package will fail opam lint.

The simplest solution is that put here - we just repeat the base-unix dependency.